### PR TITLE
Transfer runtime call stacks to AWS SQS queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ Inside the dynamodb subrepo, lives a pom.xml that we use to start dynamodb. Insi
                 "KUBERNETES_SERVICE_PORT": 6443, // Port on which your Kubernetes cluster API is running, this is generally 6443 AFAIK.
                 "KUBERNETES_SERVICE_HOST": "PATH_TO_YOUR_DEV_CLUSTER_API", // Path to a running Kubernetes cluster that we need to run the end to end tests/service end to end tests. Is of the form api.*.devcluster.openshift.com
                 "REMOTE_SERVER_URL": "" // This is the path to the layer running the origin end-to-end test wrapper.
+ 		"AWS_SQS_QueueName":   //Name of the queue where runtime call stacks are captured
+ 		"AWS_ACCESS_KEY_ID" : 
+		"AWS_SECRET_ACCESS_KEY" :
             }
 ```
 
@@ -88,10 +91,7 @@ curl -X GET \
 ```
 ### Patching source code to add imports/functions and prepend statements: patchsource
 * The patchsource binary takes in a source directory and a yaml config which contains the imports to be added to each non-ignored package/file etc. and patches all the .go files in the source directory to modify them. 
-Please refer to 'patchtemplate.yaml'. Patching involve transfer of all the runtime paths to AWS SQS queues for removing duplicate call stacks. You need to set these env. variables:
-1) AWS_SQS_QueueName (Name of the queue where runtime call stacks are captured)
-2) AWS_ACCESS_KEY_ID
-3) AWS_SECRET_ACCESS_KEY
+Please refer to 'patchtemplate.yaml'. Patching involve transfer of all the runtime paths to AWS SQS queues for removing duplicate call stacks. 
 
 * Sample config:
 ```yaml
@@ -107,7 +107,7 @@ prepend_body: |
 ```
 The above yaml, when saved in a file called `source_config.yaml` and passed to the binary as with:
 ```bash
-  $ patchsource --source-dir=[path_to_origin_dir] --code-config-yaml=sources_config.yaml  # Excludes vendor, to include it see below.
+  $ patchsource --source-dir=[path_to_origin_dir] --AWS_SQS_QueueName=queue_name --code-config-yaml=sources_config.yaml  # Excludes vendor, to include it see below.
 ```
 will change all packages of the source pointed to by source dir to:
   - Add imports marked under imports with the name as the key and the importpath as the value to the function, i.e. `godefaultfmt: fmt` becomes `import godefaultfmt "fmt"` in the Go source code.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,12 @@ curl -X GET \
 }'
 ```
 ### Patching source code to add imports/functions and prepend statements: patchsource
-* The patchsource binary takes in a source directory and a yaml config which contains the imports to be added to each non-ignored package/file etc. and patches all the .go files in the source directory to modify them.
+* The patchsource binary takes in a source directory and a yaml config which contains the imports to be added to each non-ignored package/file etc. and patches all the .go files in the source directory to modify them. 
+Please refer to 'patchtemplate.yaml'. Patching involve transfer of all the runtime paths to AWS SQS queues for removing duplicate call stacks. You need to set these env. variables:
+1) AWS_SQS_QueueName (Name of the queue where runtime call stacks are captured)
+2) AWS_ACCESS_KEY_ID
+3) AWS_SECRET_ACCESS_KEY
+
 * Sample config:
 ```yaml
 imports:

--- a/README.md
+++ b/README.md
@@ -54,9 +54,10 @@ Inside the dynamodb subrepo, lives a pom.xml that we use to start dynamodb. Insi
                 "KUBERNETES_SERVICE_PORT": 6443, // Port on which your Kubernetes cluster API is running, this is generally 6443 AFAIK.
                 "KUBERNETES_SERVICE_HOST": "PATH_TO_YOUR_DEV_CLUSTER_API", // Path to a running Kubernetes cluster that we need to run the end to end tests/service end to end tests. Is of the form api.*.devcluster.openshift.com
                 "REMOTE_SERVER_URL": "" // This is the path to the layer running the origin end-to-end test wrapper.
- 		"AWS_SQS_QueueName":   //Name of the queue where runtime call stacks are captured
- 		"AWS_ACCESS_KEY_ID" : 
-		"AWS_SECRET_ACCESS_KEY" :
+ 	            	"AWS_SQS_QueueName":   //Name of the queue where runtime call stacks are captured
+                "AWS_SQS_REGION":     // AWS region where SQS queue is located
+ 		            "AWS_ACCESS_KEY_ID" :   // AWS access key
+		            "AWS_SECRET_ACCESS_KEY" : // AWS secret 
             }
 ```
 
@@ -107,7 +108,7 @@ prepend_body: |
 ```
 The above yaml, when saved in a file called `source_config.yaml` and passed to the binary as with:
 ```bash
-  $ patchsource --source-dir=[path_to_origin_dir] --AWS_SQS_QueueName=queue_name --code-config-yaml=sources_config.yaml  # Excludes vendor, to include it see below.
+  $ patchsource --source-dir=[path_to_origin_dir] --AWS_SQS_REGION=us-west-2 --AWS_SQS_QueueName=queue_name --code-config-yaml=sources_config.yaml  # Excludes vendor, to include it see below.
 ```
 will change all packages of the source pointed to by source dir to:
   - Add imports marked under imports with the name as the key and the importpath as the value to the function, i.e. `godefaultfmt: fmt` becomes `import godefaultfmt "fmt"` in the Go source code.

--- a/patch-template.yaml
+++ b/patch-template.yaml
@@ -1,10 +1,12 @@
 imports:
-  patchfmt: fmt
   patchinfo: runtime/debug
   patchos: os
   patchio: io
   patchbytes: bytes
   patchstack: github.com/maruel/panicparse/stack
+  patchjson:  encoding/json
+  patchqueue: github.com/fabric8-analytics/poc-ocp-upgrade-prediction/pkg/utils
+
 func_name:
   logStatement
 func_body: |
@@ -17,14 +19,14 @@ func_body: |
     }
 
     // Find out similar goroutine traces and group them into buckets.
-    buckets := patchstack.Aggregate(c.Goroutines, patchstack.AnyValue)
+    buckets := patchstack.Aggregate(c.Goroutines, patchstack.ExactLines)
 
     // Calculate alignment.
     srcLen := 0
     pkgLen := 0
     for _, bucket := range buckets {
         for _, line := range bucket.Signature.Stack.Calls {
-            if l := len(line.SrcLine()); l > srcLen {
+            if l := len(line.FullSrcLine()); l > srcLen {
                 srcLen = l
             }
             if l := len(line.Func.PkgName()); l > pkgLen {
@@ -36,6 +38,8 @@ func_body: |
     for _, bucket := range buckets {
         // Print the goroutine header.
         extra := ""
+        bucketjson, _ := patchjson.Marshal(bucket)
+        go patchqueue.PublishCallStack(string(bucketjson), 1)
         if s := bucket.SleepString(); s != "" {
             extra += " [" + s + "]"
         }
@@ -44,16 +48,6 @@ func_body: |
         }
         if c := bucket.CreatedByString(false); c != "" {
             extra += " [Created by " + c + "]"
-        }
-        patchfmt.Printf("%s %d: %s%s\n", bucket.IDs, len(bucket.IDs), bucket.State, extra)
-        patchfmt.Print("--------------------------------------------------------")
-
-        // Print the stack lines.
-        for _, line := range bucket.Stack.Calls {
-            patchfmt.Printf(
-                "    %-*s %-*s %s(%s)\n",
-                pkgLen, line.Func.PkgName(), srcLen, line.SrcLine(),
-                line.Func.Name(), &line.Args)
         }
         if bucket.Stack.Elided {
             patchio.WriteString(patchos.Stdout, "    (...)\n")

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -356,9 +356,16 @@ func ReadCodeFromYaml(configYamlPath string) *PatchSourceComponents {
 	return &components
 }
 
+// Create a new SQS queue if not created already to store  the entire raw collection of runtime call stacks
 func CreateSQSQueue(queuename string) {
+
+	AWSSQSRegion := os.Getenv("AWS_SQS_REGION")
+	if AWSSQSRegion == "" {
+		AWSSQSRegion = "us-west-2"
+	}
+
 	sess, err := awssession.NewSession(&aws.Config{
-        Region: aws.String("us-west-2")},
+        Region: aws.String(AWSSQSRegion)},
 	)
 	if err != nil {
 		sugarLogger.Fatalf("Could not connect to AWS for creating SQS queue %s : %v", queuename, err)
@@ -382,8 +389,8 @@ func CreateSQSQueue(queuename string) {
 	}
 }
 
+// publish entire raw collection of runtime call stacks
 func PublishCallStack(callstackjson string, callstackid int) {
-
 	if AWSService == nil {
 			fmt.Println("--- AWS session is not available")
 			AWSSQSQueueName = os.Getenv("AWS_SQS_QueueName")

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -19,10 +19,17 @@ import (
 
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v2"
+	"github.com/aws/aws-sdk-go/aws"
+    awssession "github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"strconv"
 )
 
 var logger, _ = zap.NewDevelopment()
 var sugarLogger = logger.Sugar()
+var AWSService 			*sqs.SQS
+var AWSSQSQueueUrl 		string
+var AWSSQSQueueName	   	string
 
 // RunCloneShell runs a git clone inside a child shell and clones it as a subdir inside destdir in the workspace style
 // of go. Returns false if nothing is cloned
@@ -347,4 +354,60 @@ func ReadCodeFromYaml(configYamlPath string) *PatchSourceComponents {
 	}
 
 	return &components
+}
+
+func CreateSQSQueue(queuename string) {
+	sess, err := awssession.NewSession(&aws.Config{
+        Region: aws.String("us-west-2")},
+	)
+	if err != nil {
+		sugarLogger.Fatalf("Could not connect to AWS for creating SQS queue %s : %v", queuename, err)
+		return 
+	}
+
+	AWSService = sqs.New(sess)
+    response, err := AWSService.CreateQueue(&sqs.CreateQueueInput{
+        QueueName: aws.String(queuename),
+        Attributes: map[string]*string{
+            "DelaySeconds":           aws.String("120"),
+            "MessageRetentionPeriod": aws.String("172800"),
+		},
+	})
+	
+	if err != nil {
+		fmt.Printf("Could not create SQS queue %s : %v", queuename, err)
+	} else {
+		fmt.Printf("--- Successfully created queue with the name : ", queuename)
+		AWSSQSQueueUrl = *response.QueueUrl
+	}
+}
+
+func PublishCallStack(callstackjson string, callstackid int) {
+
+	if AWSService == nil {
+			fmt.Println("--- AWS session is not available")
+			AWSSQSQueueName = os.Getenv("AWS_SQS_QueueName")
+			if AWSSQSQueueName == "" {
+				AWSSQSQueueName = "ocp-test-upgrade"
+			}
+			CreateSQSQueue(AWSSQSQueueName)
+	}
+	if AWSService != nil {
+		response, err := AWSService.SendMessage(&sqs.SendMessageInput{
+			DelaySeconds: aws.Int64(20),
+			MessageAttributes: map[string]*sqs.MessageAttributeValue{
+				"CallStack_ID": &sqs.MessageAttributeValue{
+					DataType:    aws.String("String"),
+					StringValue: aws.String(strconv.Itoa(callstackid)),
+				},
+			},	
+			MessageBody: aws.String(callstackjson),
+			QueueUrl:    &AWSSQSQueueUrl,
+		})	
+		if err != nil {
+			fmt.Printf("Could not send message %s : %v", callstackjson, err)
+		} else {
+			fmt.Printf("--- Successfully sent message %s : ", *response.MessageId)
+		}
+	}
 }


### PR DESCRIPTION
Enable transfer of all the runtime paths from an OpenShift cluster